### PR TITLE
Be able to create an alias content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ py34default: &py34default
     - image: circleci/python:3.4
   steps:
    - setup_remote_docker:
-       docker_layer_caching: true
+       docker_layer_caching: false
    - checkout
    - attach_workspace:
        at: /tmp/images
@@ -17,7 +17,7 @@ py35default: &py35default
     - image: circleci/python:3.5
   steps:
    - setup_remote_docker:
-       docker_layer_caching: true
+       docker_layer_caching: false
    - checkout
    - attach_workspace:
        at: /tmp/images
@@ -29,7 +29,7 @@ py36default: &py36default
     - image: circleci/python:3.6
   steps:
    - setup_remote_docker:
-       docker_layer_caching: true
+       docker_layer_caching: false
    - checkout
    - attach_workspace:
        at: /tmp/images
@@ -55,7 +55,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.4 -t py34 .
       - run: mkdir images
       - run: docker save -o images/py34.tar py34
@@ -68,7 +68,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.5 -t py35 .
       - run: mkdir images
       - run: docker save -o images/py35.tar py35
@@ -81,7 +81,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.6 -t py36 .
       - run: mkdir images
       - run: docker save -o images/py36.tar py36

--- a/djangocms_alias/forms.py
+++ b/djangocms_alias/forms.py
@@ -309,16 +309,22 @@ class AliasPluginForm(forms.ModelForm):
 
 class AliasContentForm(forms.ModelForm):
 
-    alias = forms.ModelChoiceField(
-        queryset=AliasModel.objects.all(),
-        required=True,
-        widget=forms.HiddenInput(),
-    )
-    language = forms.CharField(widget=forms.HiddenInput())
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        initial = kwargs.get('initial', {})
+        if initial.get('alias'):
+            self.fields['alias'] = forms.ModelChoiceField(
+                queryset=AliasModel.objects.all(),
+                required=True,
+                widget=forms.HiddenInput(),
+            )
+
+        if initial.get('language'):
+            self.fields['language'] = forms.CharField(widget=forms.HiddenInput())
 
     class Meta:
         model = AliasContent
-        fields = ('name',)
+        fields = ('name', 'alias', 'language')
 
     def clean(self):
         cleaned_data = super().clean()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1222,9 +1222,21 @@ class AliasViewsTestCase(BaseAliasPluginTestCase):
                     alias=alias.pk,
                 )
             )
+            form = response.context_data['adminform'].form
 
+        self.assertEquals(len(form.hidden_fields()), 2)
         self.assertContains(response, 'type="hidden" name="language" value="fr"')
         self.assertContains(response, 'type="hidden" name="alias" value="{}"'.format(alias.pk))
+
+    def test_aliascontent_add_view_get_without_parameters(self):
+        '''Fields should not be hidden if parameters are not supplied'''
+        Alias.objects.create(category=self.category)
+        self.client.force_login(self.superuser)
+        url = admin_reverse('djangocms_alias_aliascontent_add')
+        response = self.client.get(url)
+        form = response.context_data['adminform'].form
+
+        self.assertEquals(form.hidden_fields(), [])
 
     def test_aliascontent_add_view_invalid_data(self):
         alias = Alias.objects.create(category=self.category)


### PR DESCRIPTION
Prior to this patch you couldn't create an alias content in admin as there were fields that were required that were hidden. The commit where this change happened: https://github.com/divio/djangocms-alias/pull/21/commits/ac124e70abd3719c209aacdbee06b3a4bae57876 contains no clue why this change was made in the first place. So the assumption is that this functionality was not checked. 

The existing tests told the story that we expect to be able to pre-fill this admin through parameters. So we preserve this functionality while keeping the flexibility to add an alias-content without needing parameters. When no parameters are supplied we show the fields.  