### PR TITLE
Remove docker caching and py3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,11 @@
 version: 2.0
 
-py34default: &py34default
-  docker:
-    - image: circleci/python:3.4
-  steps:
-   - setup_remote_docker:
-       docker_layer_caching: true
-   - checkout
-   - attach_workspace:
-       at: /tmp/images
-   - run: docker load -i /tmp/images/py34.tar || true
-   - run: docker run py34 tox -e $CIRCLE_STAGE
-
 py35default: &py35default
   docker:
     - image: circleci/python:3.5
   steps:
    - setup_remote_docker:
-       docker_layer_caching: true
+       docker_layer_caching: false
    - checkout
    - attach_workspace:
        at: /tmp/images
@@ -29,16 +17,12 @@ py36default: &py36default
     - image: circleci/python:3.6
   steps:
    - setup_remote_docker:
-       docker_layer_caching: true
+       docker_layer_caching: false
    - checkout
    - attach_workspace:
        at: /tmp/images
    - run: docker load -i /tmp/images/py36.tar || true
    - run: docker run py36 tox -e $CIRCLE_STAGE
-
-py34_requires: &py34_requires
-  requires:
-    - py34_base
 
 py35_requires: &py35_requires
   requires:
@@ -49,26 +33,13 @@ py36_requires: &py36_requires
     - py36_base
 
 jobs:
-  py34_base:
-    docker:
-      - image: circleci/python:3.4
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.4 -t py34 .
-      - run: mkdir images
-      - run: docker save -o images/py34.tar py34
-      - persist_to_workspace:
-         root: images
-         paths: py34.tar
   py35_base:
     docker:
       - image: circleci/python:3.5
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.5 -t py35 .
       - run: mkdir images
       - run: docker save -o images/py35.tar py35
@@ -81,7 +52,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.6 -t py36 .
       - run: mkdir images
       - run: docker save -o images/py36.tar py36
@@ -95,16 +66,12 @@ jobs:
     <<: *py35default
   py36-dj111-sqlite-cms40-default:
     <<: *py36default
-  py34-dj20-sqlite-cms40-default:
-    <<: *py34default
   py35-dj20-sqlite-cms40-default:
     <<: *py35default
   py36-dj20-sqlite-cms40-default:
     <<: *py36default
   py36-dj21-sqlite-cms40-default:
     <<: *py36default
-  py34-dj111-sqlite-cms40-versioning:
-    <<: *py34default
   py35-dj20-sqlite-cms40-versioning:
     <<: *py35default
   py36-dj21-sqlite-cms40-versioning:
@@ -116,7 +83,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - py34_base
       - py35_base
       - py36_base
       - flake8:
@@ -128,9 +94,6 @@ workflows:
       - py36-dj111-sqlite-cms40-default:
           requires:
             - py36_base
-      - py34-dj20-sqlite-cms40-default:
-          requires:
-            - py34_base
       - py35-dj20-sqlite-cms40-default:
           requires:
             - py35_base
@@ -140,9 +103,6 @@ workflows:
       - py36-dj21-sqlite-cms40-default:
           requires:
             - py36_base
-      - py34-dj111-sqlite-cms40-versioning:
-          requires:
-            - py34_base
       - py35-dj20-sqlite-cms40-versioning:
           requires:
             - py35_base

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ CLASSIFIERS = [
 INSTALL_REQUIREMENTS = [
     'Django>=1.11,<2.2',
     'django-parler>=1.4',
-    # 'django-cms>=3.6',  # not released
+    'django-cms'
 ]
 
 setup(
@@ -44,4 +44,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     test_suite='test_settings.run',
+    dependency_links=[
+        'http://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0',
+    ]
 )

--- a/test_settings.py
+++ b/test_settings.py
@@ -2,7 +2,7 @@ import os
 
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-ENABLE_VERSIONING = bool(os.environ.get('ENABLE_VERSIONING', False))
+ENABLE_VERSIONING = bool(os.environ.get('ENABLE_VERSIONING', True))
 EXTRA_INSTALLED_APPS = []
 if ENABLE_VERSIONING:
     EXTRA_INSTALLED_APPS.append('djangocms_versioning')


### PR DESCRIPTION
This removes the docker caching layer so tests can pass. We also remove python 3.4 since this version is deprecated since 2019. 