### PR TITLE
Bugfix - Alias category error with no valid translations for current language

### DIFF
--- a/djangocms_alias/models.py
+++ b/djangocms_alias/models.py
@@ -60,7 +60,8 @@ class Category(TranslatableModel):
         verbose_name_plural = _('categories')
 
     def __str__(self):
-        return self.name
+        # Be sure to be able to see the category name even if it's not in the current language
+        return self.safe_translation_getter("name", any_language=True)
 
     def get_absolute_url(self):
         return admin_reverse(LIST_ALIASES_URL_NAME, args=[self.pk])

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,12 @@ CLASSIFIERS = [
 INSTALL_REQUIREMENTS = [
     'Django>=1.11,<3.0',
     'django-parler>=1.4',
-    'django-cms'
+    'django-cms',
 ]
 
 TEST_REQUIRE = [
-    'djangocms-versioning'
+    "djangocms_helper",
+    'djangocms-versioning',
 ]
 
 setup(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -396,3 +396,32 @@ class AliasModelsTestCase(BaseAliasPluginTestCase):
         self.assertFalse(alias.__class__.objects.filter(pk=alias.pk).exists())
         self.assertEqual(alias.cms_plugins.count(), 0)
         self.assertEqual(Placeholder.objects.count(), 0)
+
+
+class AliasCategoryModelTestCase(BaseAliasPluginTestCase):
+
+    def test_create_alias_category_with_no_fallback_fails_gracefully(self):
+        """When creating an Alias via the Wizard an error can occur if the category
+        doesn't have a valid translation
+
+        Various ways to handle fallbacks:
+        https://django-parler.readthedocs.io/en/stable/advanced/fallback.html
+
+        Cat wizard has get all query:
+        https://github.com/divio/djangocms-alias/blob/9a9f3020aa0a01339164094c2bc1caf190d66428/djangocms_alias/forms.py#L90
+
+        Cat definitiona doesn't handle not having a fallback:
+        https://github.com/divio/djangocms-alias/blob/master/djangocms_alias/models.py#L63
+        """
+
+        # activate("ja")
+        japanese_category = Category.objects.language('ja').create(name='Japanese category')
+
+        categories = Category.objects.all()
+        
+        # A default category is created in the base as well as our Japanese category
+        self.assertEqual(2, categories.count())
+
+        for catagory in categories:
+            # Each category name property can be accessed without an error
+            self.assertTrue(bool(catagory.name))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -396,32 +396,3 @@ class AliasModelsTestCase(BaseAliasPluginTestCase):
         self.assertFalse(alias.__class__.objects.filter(pk=alias.pk).exists())
         self.assertEqual(alias.cms_plugins.count(), 0)
         self.assertEqual(Placeholder.objects.count(), 0)
-
-
-class AliasCategoryModelTestCase(BaseAliasPluginTestCase):
-
-    def test_create_alias_category_with_no_fallback_fails_gracefully(self):
-        """When creating an Alias via the Wizard an error can occur if the category
-        doesn't have a valid translation
-
-        Various ways to handle fallbacks:
-        https://django-parler.readthedocs.io/en/stable/advanced/fallback.html
-
-        Cat wizard has get all query:
-        https://github.com/divio/djangocms-alias/blob/9a9f3020aa0a01339164094c2bc1caf190d66428/djangocms_alias/forms.py#L90
-
-        Cat definitiona doesn't handle not having a fallback:
-        https://github.com/divio/djangocms-alias/blob/master/djangocms_alias/models.py#L63
-        """
-
-        # activate("ja")
-        japanese_category = Category.objects.language('ja').create(name='Japanese category')
-
-        categories = Category.objects.all()
-        
-        # A default category is created in the base as well as our Japanese category
-        self.assertEqual(2, categories.count())
-
-        for catagory in categories:
-            # Each category name property can be accessed without an error
-            self.assertTrue(bool(catagory.name))

--- a/tests/test_wizards.py
+++ b/tests/test_wizards.py
@@ -3,6 +3,7 @@ from django.contrib.sites.models import Site
 from cms.wizards.forms import WizardStep2BaseForm, step2_form_factory
 from cms.wizards.helpers import get_entries as get_wizard_entires
 
+from djangocms_alias.models import Category
 from djangocms_alias.utils import is_versioning_enabled
 
 from .base import BaseAliasPluginTestCase
@@ -66,6 +67,33 @@ class WizardsTestCase(BaseAliasPluginTestCase):
         if is_versioning_enabled():
             from djangocms_versioning.models import Version
             self.assertEqual(Version.objects.filter_by_grouper(alias).count(), 1)
+
+    def test_create_alias_wizard_form_with_no_category_fallback_language(self):
+        """When creating an Alias via the Wizard an error can occur if the category
+        doesn't have a valid translation
+        """
+        # A japanese translation that does not have any fallback settings!
+        Category.objects.language('ja').create(name='Japanese category')
+
+        wizard = self._get_wizard_instance('CreateAliasWizard')
+        data = {
+            'name': 'Content #1',
+            'category': None,
+        }
+
+        form_class = step2_form_factory(
+            mixin_cls=WizardStep2BaseForm,
+            entry_form_class=wizard.form,
+        )
+        form = form_class(**self._get_form_kwargs(data))
+
+        categories = form.declared_fields['category'].queryset.all()
+
+        for category in categories:
+            # Each category string representation can be accessed without an error
+            category_name = str(category)
+
+            self.assertTrue(category_name)
 
     def test_create_alias_category_wizard_instance(self):
         wizard = self._get_wizard_instance('CreateAliasCategoryWizard')


### PR DESCRIPTION
Provide a fix for when a category doesn't have a valid fallback in the current language. Currently affects being able to create an Alias via the wizard because the wizard uses a direct query.

Possible solutions are to either change the Category query in the Create Alias Wizard or to return the Name property in a safe manor. 

Various ways to handle fallbacks:
        https://django-parler.readthedocs.io/en/stable/advanced/fallback.html

Category wizard has get all query:
        https://github.com/divio/djangocms-alias/blob/9a9f3020aa0a01339164094c2bc1caf190d66428/djangocms_alias/forms.py#L90

Category definition doesn't handle not having a fallback:
https://github.com/divio/djangocms-alias/blob/9a9f3020aa0a01339164094c2bc1caf190d66428/djangocms_alias/models.py#L63
