### PR TITLE
Added a language filter to aid standalone and with versioning multilingual controls

### DIFF
--- a/djangocms_alias/admin.py
+++ b/djangocms_alias/admin.py
@@ -90,7 +90,7 @@ class AliasContentAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
 
-        # Only emit content changes if versioning is not installed
+        # Only emit content changes if Versioning is not installed because
         # Versioning emits it's own signals for changes
         if not is_versioning_enabled():
             emit_content_change([obj], sender=self.model)
@@ -98,7 +98,7 @@ class AliasContentAdmin(admin.ModelAdmin):
     def delete_model(self, request, obj):
         super().delete_model(request, obj)
 
-        # Only emit content changes if versioning is not installed
+        # Only emit content changes if Versioning is not installed because
         # Versioning emits it's own signals for changes
         if not is_versioning_enabled():
             emit_content_delete([obj], sender=self.model)

--- a/djangocms_alias/admin.py
+++ b/djangocms_alias/admin.py
@@ -4,6 +4,7 @@ from cms.utils.permissions import get_model_permission_codename
 
 from parler.admin import TranslatableAdmin
 
+from .filters import LanguageFilter
 from .forms import AliasContentForm
 from .models import Alias, AliasContent, Category
 from .urls import urlpatterns
@@ -80,6 +81,7 @@ class AliasAdmin(admin.ModelAdmin):
 @admin.register(AliasContent)
 class AliasContentAdmin(admin.ModelAdmin):
     form = AliasContentForm
+    list_filter = (LanguageFilter,)
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)

--- a/djangocms_alias/admin.py
+++ b/djangocms_alias/admin.py
@@ -91,7 +91,7 @@ class AliasContentAdmin(admin.ModelAdmin):
         super().save_model(request, obj, form, change)
 
         # Only emit content changes if versioning is not installed
-        # Versioning emits content changes
+        # Versioning emits it's own signals for changes
         if not is_versioning_enabled():
             emit_content_change([obj], sender=self.model)
 
@@ -99,6 +99,6 @@ class AliasContentAdmin(admin.ModelAdmin):
         super().delete_model(request, obj)
 
         # Only emit content changes if versioning is not installed
-        # Versioning emits content changes
+        # Versioning emits it's own signals for changes
         if not is_versioning_enabled():
             emit_content_delete([obj], sender=self.model)

--- a/djangocms_alias/admin.py
+++ b/djangocms_alias/admin.py
@@ -8,7 +8,11 @@ from .filters import LanguageFilter
 from .forms import AliasContentForm
 from .models import Alias, AliasContent, Category
 from .urls import urlpatterns
-from .utils import emit_content_change, emit_content_delete
+from .utils import (
+    emit_content_change,
+    emit_content_delete,
+    is_versioning_enabled,
+)
 
 
 __all__ = [
@@ -85,8 +89,16 @@ class AliasContentAdmin(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
-        emit_content_change([obj], sender=self.model)
+
+        # Only emit content changes if versioning is not installed
+        # Versioning emits content changes
+        if not is_versioning_enabled():
+            emit_content_change([obj], sender=self.model)
 
     def delete_model(self, request, obj):
         super().delete_model(request, obj)
-        emit_content_delete([obj], sender=self.model)
+
+        # Only emit content changes if versioning is not installed
+        # Versioning emits content changes
+        if not is_versioning_enabled():
+            emit_content_delete([obj], sender=self.model)

--- a/djangocms_alias/cms_config.py
+++ b/djangocms_alias/cms_config.py
@@ -25,10 +25,14 @@ class AliasCMSConfig(CMSAppConfig):
         settings, 'VERSIONING_ALIAS_MODELS_ENABLED', True)
     if djangocms_versioning_enabled:
         from djangocms_versioning.datastructures import VersionableItem
+        from cms.utils.i18n import get_language_tuple
+
         versioning = [
             VersionableItem(
                 content_model=AliasContent,
                 grouper_field_name='alias',
+                extra_grouping_fields=["language"],
+                version_list_filter_lookups={"language": get_language_tuple},
                 copy_function=copy_alias_content,
                 grouper_selector_option_label=lambda obj, lang: obj.get_name(lang),
             ),

--- a/djangocms_alias/cms_toolbars.py
+++ b/djangocms_alias/cms_toolbars.py
@@ -53,8 +53,7 @@ class AliasToolbar(CMSToolbar):
         if isinstance(self.toolbar.obj, AliasContent):
             self.add_alias_menu()
             self.override_language_switcher()
-            if not is_versioning_enabled():
-                self.change_language_menu()
+            self.change_language_menu()
 
     def post_template_populate(self):
         if self.is_current_app or isinstance(self.toolbar.obj, AliasContent):
@@ -179,9 +178,12 @@ class AliasToolbar(CMSToolbar):
             language_menu.remove_item(item=_item)
 
         for code, name in get_language_tuple(self.current_site.pk):
-            # Showing only existing translation. For versioning it will be only
-            # published translation
-            alias_content = self.toolbar.obj.alias.get_content(language=code)
+            # Showing only existing translation. For versioning it will be the
+            # latest translation i.e. draft or published
+            alias_content = self.toolbar.obj.alias.get_content(
+                language=code,
+                show_draft_content=True,
+            )
             if alias_content:
                 with force_language(code):
                     url = alias_content.get_absolute_url()
@@ -237,7 +239,10 @@ class AliasToolbar(CMSToolbar):
                 )
                 disabled = len(remove) == 1
                 for code, name in remove:
-                    alias_content = alias_content.alias.get_content(language=code)
+                    alias_content = alias_content.alias.get_content(
+                        language=code,
+                        show_draft_content=True,
+                    )
                     translation_delete_url = admin_reverse(
                         'djangocms_alias_aliascontent_delete',
                         args=(alias_content.pk,),
@@ -259,13 +264,19 @@ class AliasToolbar(CMSToolbar):
                     copy_url = admin_reverse('djangocms_alias_alias_copy_plugins')
 
                 for code, name in copy:
+                    source_placeholder = alias_content.alias.get_placeholder(
+                        language=code,
+                        show_draft_content=True,
+                    )
                     copy_plugins_menu.add_ajax_item(
-                        title % name, action=copy_url,
+                        title % name,
+                        action=copy_url,
                         data={
                             'source_language': code,
-                            'source_placeholder_id': alias_content.alias.get_placeholder(code).pk,
+                            'source_placeholder_id': source_placeholder.pk,
                             'target_language': self.current_lang,
                             'target_placeholder_id': current_placeholder.pk,
                         },
-                        question=question % name, on_success=self.toolbar.REFRESH_PAGE
+                        question=question % name,
+                        on_success=self.toolbar.REFRESH_PAGE
                     )

--- a/djangocms_alias/cms_toolbars.py
+++ b/djangocms_alias/cms_toolbars.py
@@ -210,7 +210,7 @@ class AliasToolbar(CMSToolbar):
                 for code in alias_content.alias.get_languages()
                 if code in languages
             ]
-            add = [l for l in languages.items() if l not in remove]
+            add = [code for code in languages.items() if code not in remove]
             copy = [
                 (code, name)
                 for code, name in languages.items()

--- a/djangocms_alias/cms_toolbars.py
+++ b/djangocms_alias/cms_toolbars.py
@@ -29,7 +29,6 @@ from .constants import (
     USAGE_ALIAS_URL_NAME,
 )
 from .models import Alias, AliasContent
-from .utils import is_versioning_enabled
 
 
 __all__ = [

--- a/djangocms_alias/filters.py
+++ b/djangocms_alias/filters.py
@@ -1,0 +1,33 @@
+from django.contrib import admin
+from django.utils.translation import ugettext_lazy as _
+
+from cms.utils.i18n import get_language_tuple, get_site_language_from_request
+
+
+class LanguageFilter(admin.SimpleListFilter):
+    title = _("language")
+    parameter_name = "language"
+
+    def lookups(self, request, model_admin):
+        return get_language_tuple()
+
+    def queryset(self, request, queryset):
+        language = self.value()
+        if language is None:
+            language = get_site_language_from_request(request)
+        return queryset.filter(language=language)
+
+    def choices(self, changelist):
+        yield {
+            "selected": self.value() is None,
+            "query_string": changelist.get_query_string(remove=[self.parameter_name]),
+            "display": _("Current"),
+        }
+        for lookup, title in self.lookup_choices:
+            yield {
+                "selected": self.value() == str(lookup),
+                "query_string": changelist.get_query_string(
+                    {self.parameter_name: lookup}
+                ),
+                "display": title,
+            }

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -33,7 +33,7 @@ class FiltersTestCase(CMSTestCase):
 
         base_url = self.get_admin_url(AliasContent, "changelist")
 
-        with self.login_user_context(self.get_superuser()):
+        with self.login_user_context(self.superuser):
             # en is the default language configured for the site
             response_default = self.client.get(base_url)
             qs_default = response_default.context["cl"].queryset
@@ -43,11 +43,11 @@ class FiltersTestCase(CMSTestCase):
             # de should have a result
             response_de = self.client.get(base_url + "?language=de")
             qs_de = response_de.context["cl"].queryset
-            # fr should have no result and be empty
+            # fr should have no result and be empty because nothing was created
             response_fr = self.client.get(base_url + "?language=fr")
             qs_fr = response_fr.context["cl"].queryset
 
-        self.assertEqual(set(qs_default), set(expected_en_content))
-        self.assertEqual(set(qs_en), set(expected_en_content))
-        self.assertEqual(set(qs_de), set(expected_de_content))
-        self.assertEqual(set(qs_fr), set())
+        self.assertEqual(set(qs_default), set([expected_en_content]))
+        self.assertEqual(set(qs_en), set([expected_en_content]))
+        self.assertEqual(set(qs_de), set([expected_de_content]))
+        self.assertEqual(set(qs_fr), set([]))

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,53 @@
+from cms.test_utils.testcases import CMSTestCase
+
+from djangocms_alias.models import Alias as AliasModel, AliasContent, Category
+from djangocms_alias.utils import is_versioning_enabled
+
+
+class FiltersTestCase(CMSTestCase):
+    def setUp(self):
+        self.superuser = self.get_superuser()
+
+    def test_language_filter(self):
+        category = Category.objects.create(name='Language Filter Category')
+        alias = AliasModel.objects.create(
+            category=category,
+            position=0,
+        )
+        expected_en_content = AliasContent.objects.create(
+            alias=alias,
+            name="EN Alias Content",
+            language="en",
+        )
+        expected_de_content = AliasContent.objects.create(
+            alias=alias,
+            name="DE Alias Content",
+            language="de",
+        )
+        # If versioning is enabled be sure to create a version
+        if is_versioning_enabled():
+            from djangocms_versioning.models import Version
+
+            Version.objects.create(content=expected_en_content, created_by=self.superuser)
+            Version.objects.create(content=expected_de_content, created_by=self.superuser)
+
+        base_url = self.get_admin_url(AliasContent, "changelist")
+
+        with self.login_user_context(self.get_superuser()):
+            # en is the default language configured for the site
+            response_default = self.client.get(base_url)
+            qs_default = response_default.context["cl"].queryset
+            # en should have a result
+            response_en = self.client.get(base_url + "?language=en")
+            qs_en = response_en.context["cl"].queryset
+            # de should have a result
+            response_de = self.client.get(base_url + "?language=de")
+            qs_de = response_de.context["cl"].queryset
+            # fr should have no result and be empty
+            response_fr = self.client.get(base_url + "?language=fr")
+            qs_fr = response_fr.context["cl"].queryset
+
+        self.assertEqual(set(qs_default), set(expected_en_content))
+        self.assertEqual(set(qs_en), set(expected_en_content))
+        self.assertEqual(set(qs_de), set(expected_de_content))
+        self.assertEqual(set(qs_fr), set())

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -231,10 +231,15 @@ class AliasToolbarTestCase(BaseAliasPluginTestCase):
             preview=True,
         )
         language_menu = request.toolbar.get_menu(LANGUAGE_MENU_IDENTIFIER)
+        expected_result = ['English', 'Deutsche', 'Française', 'Italiano']
+        # Versioning changes the toolbar language selector and only shows
+        # languages that have translations
+        if is_versioning_enabled():
+            expected_result = ['English']
+
         # Dont change default language switcher that is used for Pages
         self.assertEqual(
-            [item.name for item in language_menu.items],
-            ['English', 'Deutsche', 'Française', 'Italiano']
+            [item.name for item in language_menu.items], expected_result
         )
 
     def test_alias_change_category_button_is_visible_on_alias_edit_view(self):

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -1,6 +1,5 @@
 import itertools
 from collections import ChainMap
-from unittest import skipIf
 
 from django.contrib.auth.models import Permission
 
@@ -89,7 +88,6 @@ class AliasToolbarTestCase(BaseAliasPluginTestCase):
         _test_alias_endpoint(edit=True)
         _test_alias_endpoint(preview=True)
 
-    #@skipIf(is_versioning_enabled(), 'Managing content is done by version admin')
     def test_alias_toolbar_language_menu(self):
         request = self.get_page_request(self.page, user=self.superuser)
         alias_menu = request.toolbar.get_menu(ALIAS_MENU_IDENTIFIER)


### PR DESCRIPTION
Alias currently has no way of selecting or adding content in different languages. This change adds the controls to enable content to be viewed and added in multiple languages.